### PR TITLE
Correct spelling error in reports table

### DIFF
--- a/setup.sql
+++ b/setup.sql
@@ -1,3 +1,7 @@
+CREATE DATABASE lecturegoggles;
+
+CONNECT TO lecturegoggles;
+
 CREATE TABLE subjects (
    id SERIAL PRIMARY KEY,
    author_id INTEGER NOT NULL,
@@ -50,7 +54,7 @@ CREATE TABLE reports (
    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
    updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
    reported_post_id INTEGER NOT NULL,
-   reported_context_extension VARCHAR(200) NOT NULL,
+   reported_content_extension VARCHAR(200) NOT NULL,
    resolved boolean DEFAULT FALSE,
    resolved_by VARCHAR(100) DEFAULT 'unresolved' NOT NULL,
    teacher_created boolean DEFAULT FALSE

--- a/setup.sql
+++ b/setup.sql
@@ -1,7 +1,3 @@
-CREATE DATABASE lecturegoggles;
-
-CONNECT TO lecturegoggles;
-
 CREATE TABLE subjects (
    id SERIAL PRIMARY KEY,
    author_id INTEGER NOT NULL,


### PR DESCRIPTION
Fix a typo in the reports table that can cause admin actions to fail.